### PR TITLE
Bugfixes and optimization

### DIFF
--- a/app/front/scripts/services/os-viewer/params.js
+++ b/app/front/scripts/services/os-viewer/params.js
@@ -461,7 +461,7 @@ function removeVisualization(state, visualizationId, packageModel) {
     return item != visualizationId;
   });
   if (result.visualizations.length == 0) {
-    clearParams(result.packageModel);
+    clearParams(result);
   }
   return result;
 }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -78,6 +78,7 @@ gulp.task('styles.vendor', function() {
   ];
   return gulp.src(files)
     .pipe(concat('vendor.css'))
+    .pipe(minifyCss({compatibility: 'ie8'}))
     .pipe(gulp.dest(publicStylesDir));
 });
 
@@ -104,7 +105,7 @@ gulp.task('scripts.application', function() {
   return bundler.bundle()
     .pipe(source('app.js'))
     .pipe(buffer())
-    //.pipe(uglify())
+    .pipe(uglify())
     .pipe(gulp.dest(publicScriptsDir));
 });
 


### PR DESCRIPTION
1. `Remove visualization` button now works.
2. Reduced size of `app.js` (from 4.1Mb to 1.3Mb) and `vendor.css` (from ~270Kb to 172Kb).
