### PR TITLE
Malformed API request in some cases

### DIFF
--- a/app/front/scripts/services/visualizations/index.js
+++ b/app/front/scripts/services/visualizations/index.js
@@ -124,6 +124,7 @@ function serializeFilters(filters) {
         .join(';')
         .value();
     })
+    .map(encodeURIComponent)
     .value();
 }
 


### PR DESCRIPTION
When `cut` param contained backslash (`\`) char, it was replaced by slash (`/`), which caused empty visualization or wrong data to be displayed.
