### PR TITLE
Disable Pivot Table vis when no column hierarchies

### DIFF
--- a/app/front/scripts/services/visualizations/index.js
+++ b/app/front/scripts/services/visualizations/index.js
@@ -109,6 +109,12 @@ function getAvailableVisualizations(packageModel) {
           return false;
         }
       }
+      if (item.type == 'pivot-table') {
+        hierarchiesAvailable = packageModel.columnHierarchies.length > 0;
+        if (!hierarchiesAvailable) {
+          return false;
+        }
+      }
       return true;
     })
     .value();


### PR DESCRIPTION
In case when all of dimensions have more than `maxValueCount` members (and as result - empty list of column hierarchies) do not show Pivot Table vis among available visualizations.

Thanks a lot @larjohn for extremely detailed bug description!

Tests fixed within PR https://github.com/openspending/os-viewer/pull/125
