### PR TITLE
Show Map viz only for Moldova

### DIFF
--- a/app/front/scripts/services/data-package-api/index.js
+++ b/app/front/scripts/services/data-package-api/index.js
@@ -61,8 +61,10 @@ function getDataPackageMetadata(dataPackage, model) {
     description: dataPackage.description,
     owner: dataPackage.owner,
     author: dataPackage.author,
-    countryCode: _.isArray(dataPackage.countryCode) ?
-      _.first(dataPackage.countryCode) : dataPackage.countryCode,
+    countryCode: (function(countryCode) {
+      var result = _.isArray(countryCode) ? _.first(countryCode) : countryCode;
+      return _.isString(result) ? result.toUpperCase() : undefined;
+    })(dataPackage.countryCode),
     // jscs:disable
     factTable: model ? model.fact_table : null,
     // jscs:enable

--- a/app/front/scripts/services/visualizations/index.js
+++ b/app/front/scripts/services/visualizations/index.js
@@ -105,7 +105,9 @@ function getAvailableVisualizations(packageModel) {
 
       if (item.type == 'location') {
         hierarchiesAvailable = packageModel.locationHierarchies.length > 0;
-        locationAvailable = !!packageModel.meta.countryCode;
+        locationAvailable = !!packageModel.meta.countryCode &&
+          // Temporarily disable GeoView for all countries except of Moldova
+          (packageModel.meta.countryCode == 'MD');
         if (!hierarchiesAvailable || !locationAvailable) {
           return false;
         }


### PR DESCRIPTION
Show Map visualization only when datapackage has `countryCode` property equal to `MD` (Moldova).
