### PR TITLE
Sort by dimension label field

### DIFF
--- a/app/front/scripts/services/data-package-api/index.js
+++ b/app/front/scripts/services/data-package-api/index.js
@@ -144,6 +144,7 @@ function getDimensionsFromModel(dataPackage, model) {
       result.key = dimension.key_ref;
       result.label = dimension.label;
       result.valueRef = dimension.label_ref || dimension.key_ref;
+      result.sortKey = dimension.label_ref || dimension.key_ref;
       // jscs:enable
       result.hierarchy = dimension.hierarchy;
 

--- a/app/front/scripts/services/os-viewer/index.js
+++ b/app/front/scripts/services/os-viewer/index.js
@@ -144,14 +144,22 @@ function getInitialState(dataPackages, pageUrl) {
 function getAvailableSorting(state) {
   var packageModel = state.package;
   var params = state.params;
-  return _.filter([
-    _.find(packageModel.measures, function(item) {
-      return params.measures.indexOf(item.key) >= 0;
-    }),
-    _.find(packageModel.dimensions, function(item) {
-      return params.groups.indexOf(item.key) >= 0;
+  return _.chain([
+      _.find(packageModel.measures, function(item) {
+        return params.measures.indexOf(item.key) >= 0;
+      }),
+      _.find(packageModel.dimensions, function(item) {
+        return params.groups.indexOf(item.key) >= 0;
+      })
+    ])
+    .filter()
+    .map(function(item) {
+      return {
+        label: item.label,
+        key: item.sortKey || item.key
+      };
     })
-  ]);
+    .value();
 }
 
 function getCurrencySign(state) {

--- a/tests/data/package1-packagemodel-bare.js
+++ b/tests/data/package1-packagemodel-bare.js
@@ -35,6 +35,7 @@ module.exports = {
       key: 'date_2.Annee',
       label: 'Année',
       valueRef: 'date_2.Annee',
+      sortKey: 'date_2.Annee',
       hierarchy: 'date',
       dimensionType: 'datetime'
     },
@@ -43,6 +44,7 @@ module.exports = {
       key: 'economic_classification_3.Article',
       label: 'Article',
       valueRef: 'economic_classification_3.Intitule_article',
+      sortKey: 'economic_classification_3.Intitule_article',
       hierarchy: 'economic_classification',
       dimensionType: 'classification'
     },
@@ -51,6 +53,7 @@ module.exports = {
       key: 'economic_classification_2.Chapitre',
       label: 'Chapitre',
       valueRef: 'economic_classification_2.Intitule_chapitre',
+      sortKey: 'economic_classification_2.Intitule_chapitre',
       hierarchy: 'economic_classification',
       dimensionType: 'classification'
     },
@@ -59,6 +62,7 @@ module.exports = {
       key: 'economic_classification_Compte.Compte',
       label: 'Compte',
       valueRef: 'economic_classification_Compte.Intitule_compte',
+      sortKey: 'economic_classification_Compte.Intitule_compte',
       hierarchy: 'economic_classification',
       dimensionType: 'classification'
     },
@@ -67,6 +71,7 @@ module.exports = {
       key: 'activity_2.Nature',
       label: 'Nature',
       valueRef: 'activity_2.Intitule_nature',
+      sortKey: 'activity_2.Intitule_nature',
       hierarchy: 'activity',
       dimensionType: 'activity'
     }
@@ -82,6 +87,7 @@ module.exports = {
           key: 'activity_2.Nature',
           label: 'Nature',
           valueRef: 'activity_2.Intitule_nature',
+          sortKey: 'activity_2.Intitule_nature',
           hierarchy: 'activity',
           dimensionType: 'activity'
         }
@@ -97,6 +103,7 @@ module.exports = {
           key: 'date_2.Annee',
           label: 'Année',
           valueRef: 'date_2.Annee',
+          sortKey: 'date_2.Annee',
           hierarchy: 'date',
           dimensionType: 'datetime'
         }
@@ -112,6 +119,7 @@ module.exports = {
           key: 'economic_classification_2.Chapitre',
           label: 'Chapitre',
           valueRef: 'economic_classification_2.Intitule_chapitre',
+          sortKey: 'economic_classification_2.Intitule_chapitre',
           hierarchy: 'economic_classification',
           dimensionType: 'classification'
         },
@@ -120,6 +128,7 @@ module.exports = {
           key: 'economic_classification_3.Article',
           label: 'Article',
           valueRef: 'economic_classification_3.Intitule_article',
+          sortKey: 'economic_classification_3.Intitule_article',
           hierarchy: 'economic_classification',
           dimensionType: 'classification'
         },
@@ -128,6 +137,7 @@ module.exports = {
           key: 'economic_classification_Compte.Compte',
           label: 'Compte',
           valueRef: 'economic_classification_Compte.Intitule_compte',
+          sortKey: 'economic_classification_Compte.Intitule_compte',
           hierarchy: 'economic_classification',
           dimensionType: 'classification'
         }
@@ -145,6 +155,7 @@ module.exports = {
           key: 'activity_2.Nature',
           label: 'Nature',
           valueRef: 'activity_2.Intitule_nature',
+          sortKey: 'activity_2.Intitule_nature',
           hierarchy: 'activity',
           dimensionType: 'activity'
         }
@@ -160,6 +171,7 @@ module.exports = {
           key: 'date_2.Annee',
           label: 'Année',
           valueRef: 'date_2.Annee',
+          sortKey: 'date_2.Annee',
           hierarchy: 'date',
           dimensionType: 'datetime'
         }
@@ -175,6 +187,7 @@ module.exports = {
           key: 'economic_classification_2.Chapitre',
           label: 'Chapitre',
           valueRef: 'economic_classification_2.Intitule_chapitre',
+          sortKey: 'economic_classification_2.Intitule_chapitre',
           hierarchy: 'economic_classification',
           dimensionType: 'classification'
         },
@@ -183,6 +196,7 @@ module.exports = {
           key: 'economic_classification_3.Article',
           label: 'Article',
           valueRef: 'economic_classification_3.Intitule_article',
+          sortKey: 'economic_classification_3.Intitule_article',
           hierarchy: 'economic_classification',
           dimensionType: 'classification'
         },
@@ -191,6 +205,7 @@ module.exports = {
           key: 'economic_classification_Compte.Compte',
           label: 'Compte',
           valueRef: 'economic_classification_Compte.Intitule_compte',
+          sortKey: 'economic_classification_Compte.Intitule_compte',
           hierarchy: 'economic_classification',
           dimensionType: 'classification'
         }
@@ -210,6 +225,7 @@ module.exports = {
           key: 'date_2.Annee',
           label: 'Année',
           valueRef: 'date_2.Annee',
+          sortKey: 'date_2.Annee',
           hierarchy: 'date',
           dimensionType: 'datetime'
         }

--- a/tests/data/package1-packagemodel.js
+++ b/tests/data/package1-packagemodel.js
@@ -35,6 +35,7 @@ module.exports = {
       key: 'date_2.Annee',
       label: 'Année',
       valueRef: 'date_2.Annee',
+      sortKey: 'date_2.Annee',
       hierarchy: 'date',
       dimensionType: 'datetime',
       values: [
@@ -49,6 +50,7 @@ module.exports = {
       key: 'economic_classification_3.Article',
       label: 'Article',
       valueRef: 'economic_classification_3.Intitule_article',
+      sortKey: 'economic_classification_3.Intitule_article',
       hierarchy: 'economic_classification',
       dimensionType: 'classification',
       values: [
@@ -99,6 +101,7 @@ module.exports = {
       key: 'economic_classification_2.Chapitre',
       label: 'Chapitre',
       valueRef: 'economic_classification_2.Intitule_chapitre',
+      sortKey: 'economic_classification_2.Intitule_chapitre',
       hierarchy: 'economic_classification',
       dimensionType: 'classification',
       values: [
@@ -141,6 +144,7 @@ module.exports = {
       key: 'economic_classification_Compte.Compte',
       label: 'Compte',
       valueRef: 'economic_classification_Compte.Intitule_compte',
+      sortKey: 'economic_classification_Compte.Intitule_compte',
       hierarchy: 'economic_classification',
       dimensionType: 'classification',
       values: [
@@ -174,6 +178,7 @@ module.exports = {
       key: 'activity_2.Nature',
       label: 'Nature',
       valueRef: 'activity_2.Intitule_nature',
+      sortKey: 'activity_2.Intitule_nature',
       hierarchy: 'activity',
       dimensionType: 'activity',
       values: [
@@ -195,6 +200,7 @@ module.exports = {
           key: 'activity_2.Nature',
           label: 'Nature',
           valueRef: 'activity_2.Intitule_nature',
+          sortKey: 'activity_2.Intitule_nature',
           hierarchy: 'activity',
           dimensionType: 'activity',
           values: [
@@ -216,6 +222,7 @@ module.exports = {
           key: 'date_2.Annee',
           label: 'Année',
           valueRef: 'date_2.Annee',
+          sortKey: 'date_2.Annee',
           hierarchy: 'date',
           dimensionType: 'datetime',
           values: [
@@ -237,6 +244,7 @@ module.exports = {
           key: 'economic_classification_2.Chapitre',
           label: 'Chapitre',
           valueRef: 'economic_classification_2.Intitule_chapitre',
+          sortKey: 'economic_classification_2.Intitule_chapitre',
           hierarchy: 'economic_classification',
           dimensionType: 'classification',
           values: [
@@ -279,6 +287,7 @@ module.exports = {
           key: 'economic_classification_3.Article',
           label: 'Article',
           valueRef: 'economic_classification_3.Intitule_article',
+          sortKey: 'economic_classification_3.Intitule_article',
           hierarchy: 'economic_classification',
           dimensionType: 'classification',
           values: [
@@ -329,6 +338,7 @@ module.exports = {
           key: 'economic_classification_Compte.Compte',
           label: 'Compte',
           valueRef: 'economic_classification_Compte.Intitule_compte',
+          sortKey: 'economic_classification_Compte.Intitule_compte',
           hierarchy: 'economic_classification',
           dimensionType: 'classification',
           values: [
@@ -371,6 +381,7 @@ module.exports = {
           key: 'activity_2.Nature',
           label: 'Nature',
           valueRef: 'activity_2.Intitule_nature',
+          sortKey: 'activity_2.Intitule_nature',
           hierarchy: 'activity',
           dimensionType: 'activity',
           values: [
@@ -392,6 +403,7 @@ module.exports = {
           key: 'date_2.Annee',
           label: 'Année',
           valueRef: 'date_2.Annee',
+          sortKey: 'date_2.Annee',
           hierarchy: 'date',
           dimensionType: 'datetime',
           values: [
@@ -413,6 +425,7 @@ module.exports = {
           key: 'economic_classification_2.Chapitre',
           label: 'Chapitre',
           valueRef: 'economic_classification_2.Intitule_chapitre',
+          sortKey: 'economic_classification_2.Intitule_chapitre',
           hierarchy: 'economic_classification',
           dimensionType: 'classification',
           values: [
@@ -455,6 +468,7 @@ module.exports = {
           key: 'economic_classification_3.Article',
           label: 'Article',
           valueRef: 'economic_classification_3.Intitule_article',
+          sortKey: 'economic_classification_3.Intitule_article',
           hierarchy: 'economic_classification',
           dimensionType: 'classification',
           values: [
@@ -505,6 +519,7 @@ module.exports = {
           key: 'economic_classification_Compte.Compte',
           label: 'Compte',
           valueRef: 'economic_classification_Compte.Intitule_compte',
+          sortKey: 'economic_classification_Compte.Intitule_compte',
           hierarchy: 'economic_classification',
           dimensionType: 'classification',
           values: [
@@ -550,6 +565,7 @@ module.exports = {
           key: 'date_2.Annee',
           label: 'Année',
           valueRef: 'date_2.Annee',
+          sortKey: 'date_2.Annee',
           hierarchy: 'date',
           dimensionType: 'datetime',
           values: [


### PR DESCRIPTION
In `sortable-series` graphs sort data sorting using dimension's label field (`label_ref`) (if available) instead of id (`key_ref`)
