### PR TITLE
Keep drilldown filters separately from user-selected

### DIFF
--- a/app/front/scripts/directives/visualizations/controls/export/index.js
+++ b/app/front/scripts/directives/visualizations/controls/export/index.js
@@ -86,7 +86,9 @@ angular.module('Application')
             try {
               encoder = new TextEncoder(charset, {
                 // Allow encodings other that utf-8
+                // jscs:disable
                 NONSTANDARD_allowLegacyEncoding: true
+                // jscs:enable
               });
             } catch (error) {
               encoder = new TextEncoder('utf-8');

--- a/app/front/scripts/services/visualizations/index.js
+++ b/app/front/scripts/services/visualizations/index.js
@@ -129,7 +129,18 @@ function getAvailableVisualizations(packageModel) {
     .value();
 }
 
-function serializeFilters(filters) {
+function serializeFilters(filters, drilldown) {
+  // Add filters from drilldown, if any
+  if (_.isArray(drilldown)) {
+    filters = _.cloneDeep(filters);
+    _.each(drilldown, function(item) {
+      // When drilldown - replace filters for all drilldown
+      // dimensions: they cannot be selected by user, but ensure
+      // that there are no any garbage
+      filters[item.dimension] = [item.filter];
+    });
+  }
+
   return _.chain(filters)
     .map(function(values, key) {
       return key + ':' + _.chain(values)
@@ -147,7 +158,7 @@ function paramsToBabbageState(params) {
   var result = {
     aggregates: _.first(params.measures),
     group: params.groups,
-    filter: serializeFilters(params.filters),
+    filter: serializeFilters(params.filters, params.drilldown),
     order: [params.orderBy]
   };
 
@@ -166,7 +177,7 @@ function paramsToBabbageStateFacts(params) {
   return {
     aggregates: _.first(params.measures),
     group: params.groups,
-    filter: serializeFilters(params.filters)
+    filter: serializeFilters(params.filters, params.drilldown)
   };
 }
 
@@ -175,7 +186,7 @@ function paramsToBabbageStatePivot(params) {
     aggregates: _.first(params.measures),
     rows: params.rows,
     cols: params.columns,
-    filter: serializeFilters(params.filters),
+    filter: serializeFilters(params.filters, params.drilldown),
     order: [params.orderBy]
   };
 }
@@ -184,7 +195,7 @@ function paramsToBabbageStateTimeSeries(params) {
   var result = {
     aggregates: _.first(params.measures),
     group: [params.dateTimeDimension],
-    filter: serializeFilters(params.filters),
+    filter: serializeFilters(params.filters, params.drilldown),
     order: [{
       key: params.dateTimeDimension,
       direction: 'asc'
@@ -211,7 +222,7 @@ function paramsToBabbageStateSankey(params) {
     aggregates: _.first(params.measures),
     source: params.source,
     target: params.target,
-    filter: serializeFilters(params.filters)
+    filter: serializeFilters(params.filters, params.drilldown)
   };
 }
 

--- a/tests/data/package1-initial-state.js
+++ b/tests/data/package1-initial-state.js
@@ -14,6 +14,7 @@ module.exports = {
     filters: {},
     orderBy: {},
     visualizations: [],
+    drilldown: [],
     packageId: 'Package1',
     countryCode: 'CM',
     dateTimeDimension: 'date_2.Annee',

--- a/tests/os-viewer.js
+++ b/tests/os-viewer.js
@@ -162,6 +162,7 @@ describe('OS Viewer core service', function() {
           key: 'Depenses_realisees.sum',
           direction: 'desc'
         },
+        drilldown: [],
         source: 'activity_2.Nature',
         target: 'activity_2.Nature',
         visualizations: ['Treemap'],


### PR DESCRIPTION
Drilldown works in such way that requires adding some filters additionally to filters selected by user. All selected filter values previously were kept together, and user was able to deselect an automatically added filters. This lead to inconsistent drilldown state. Solution: keep drilldown data in special place so user will not either see it nor change (only using drilldown-related UI - breadcrumbs and clicks on graphs). Also this solution simplified implementation of breadcrumbs.
