### PR TITLE
Select max year for some types of visualizations

### DIFF
--- a/app/front/scripts/services/os-viewer/params.js
+++ b/app/front/scripts/services/os-viewer/params.js
@@ -415,6 +415,33 @@ function initParamsForPivotTable(params, packageModel) {
   };
 }
 
+function getDefaultDateTimeFilter(params, packageModel) {
+  var result = {};
+
+  var dateTimeDimension = _.find(packageModel.dimensions, {
+    key: params.dateTimeDimension
+  });
+  if (
+    dateTimeDimension &&
+    _.isArray(dateTimeDimension.values) &&
+    (dateTimeDimension.values.length > 0)
+  ) {
+    var filters = params.filters[dateTimeDimension.key] || [];
+    if (filters.length == 0) {
+      result[dateTimeDimension.key] = [
+        _.chain(dateTimeDimension.values)
+          .map(function(item) {
+            return item.key;
+          })
+          .max()
+          .value()
+      ];
+    }
+  }
+
+  return result;
+}
+
 function initParams(params, packageModel) {
   var visualization = visualizationsService.getVisualizationById(
     _.first(params.visualizations));
@@ -431,6 +458,15 @@ function initParams(params, packageModel) {
       break;
     case 'pivot-table':
       initParamsForPivotTable(params, packageModel);
+      break;
+  }
+
+  // Filter by largest datetime dimension value for some types
+  switch (visualization.type) {
+    case 'location':
+    case 'drilldown':
+    case 'pivot-table':
+      _.extend(params.filters, getDefaultDateTimeFilter(params, packageModel));
       break;
   }
 }

--- a/app/front/scripts/services/os-viewer/params.js
+++ b/app/front/scripts/services/os-viewer/params.js
@@ -424,7 +424,7 @@ function getDefaultDateTimeFilter(params, packageModel) {
   if (
     dateTimeDimension &&
     _.isArray(dateTimeDimension.values) &&
-    (dateTimeDimension.values.length > 0)
+    (dateTimeDimension.values.length > 1)
   ) {
     var filters = params.filters[dateTimeDimension.key] || [];
     if (filters.length == 0) {


### PR DESCRIPTION
When user adds any drilldown (TreeMap, BubbleTree, Pie Chart, Sankey diagram), location (Map) or Pivot Table visualization, and no filter is selected, and there are more than one values in a datetime dimension, automatically select the largest value.
