### PR TITLE
When adding first visualization, expand auto-selected categories in sidebar

### DIFF
--- a/app/front/scripts/directives/sidebar/sidebar-list/index.js
+++ b/app/front/scripts/directives/sidebar/sidebar-list/index.js
@@ -30,6 +30,19 @@ angular.module('Application')
           }
           $scope.isSelected = isSelected;
 
+          $scope.isAnyItemSelected = function() {
+            var selected = _.chain($scope.items)
+              .map(function(item) {
+                return item.key;
+              })
+              .intersectionWith($scope.selected, function(a, b) {
+                return a == b;
+              })
+              .value();
+            $scope.isAnyItemSelected = null;
+            return selected.length > 0;
+          };
+
           $scope.selectedItems = [];
           function updateSelectedItems() {
             var selectedItems = [];

--- a/app/front/scripts/directives/sidebar/sidebar-list/template.html
+++ b/app/front/scripts/directives/sidebar/sidebar-list/template.html
@@ -1,4 +1,5 @@
 <div ng-init="list.isCollapsed = true">
+  <div ng-if="isAnyItemSelected && items.length && selected.length" ng-init="list.isCollapsed = !isAnyItemSelected()"></div>
   <div class="list-group list-group-inverse">
     <a ng-click="list.isCollapsed = !list.isCollapsed" href="javascript:void(0);" class="list-group-item">
       <i class="os-icon os-icon-filter"></i>


### PR DESCRIPTION
This allows user to see which dimensions and filters were used to build graphs.

Once user added first graph - he is free to collapse/expand any category in sidebar; no auto-expanding will be performed (until he'll remove all visualizations).
