### PR TITLE
Improvements for Sealer

### DIFF
--- a/app/front/scripts/controllers/main.js
+++ b/app/front/scripts/controllers/main.js
@@ -70,7 +70,7 @@ ngModule.controller('MainController', [
 
     // Initialization stuff
     function initRegular() {
-      $q(LoginService.tryGetToken())
+      return $q(LoginService.tryGetToken())
         .then(function(token) {
           var userId = token ? LoginService.getUserId() : null;
           var urlParams = osViewerService.parseUrl($location.url());
@@ -115,7 +115,7 @@ ngModule.controller('MainController', [
 
       var urlParams = osViewerService.parseUrl($location.url());
 
-      $q(osViewerService.loadDataPackage(urlParams.packageId, urlParams))
+      return $q(osViewerService.loadDataPackage(urlParams.packageId, urlParams))
         .then(function(state) {
           osViewerService.translateHierarchies(state, i18n);
           $scope.state = state;
@@ -137,21 +137,24 @@ ngModule.controller('MainController', [
     // Wait for one digest cycle before check `$scope.isEmbedded`
     // since `ng-init` is executed after `ng-controller`
     $timeout(function() {
-      $scope.isEmbedded ? initEmbedded() : initRegular();
+      var promise = $scope.isEmbedded ? initEmbedded() : initRegular();
+      promise.then(function() {
+        if ($scope.isMainView) {
+          // Update filter values based on current filters
+          $scope.$watch('state.params.filters', function(newValue, oldValue) {
+            if (newValue !== oldValue) {
+              updateFilterValues();
+            }
+          }, true);
+          $scope.$watch('state.params.drilldown', function(newValue, oldValue) {
+            if (newValue !== oldValue) {
+              updateFilterValues();
+            }
+          }, true);
+        }
+      });
       osViewerService.theme.set($scope.theme);
     });
-
-    // Update filer values based on current filters
-    $scope.$watch('state.params.filters', function(newValue, oldValue) {
-      if (newValue !== oldValue) {
-        updateFilterValues();
-      }
-    }, true);
-    $scope.$watch('state.params.drilldown', function(newValue, oldValue) {
-      if (newValue !== oldValue) {
-        updateFilterValues();
-      }
-    }, true);
 
     // Event listeners
 

--- a/app/front/scripts/directives/index.js
+++ b/app/front/scripts/directives/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var babbage = require('babbage.ui/lib/bindings/angular');
+var babbageApiExporter = require('babbage.ui/lib/api/exporter');
 
 var ngModule = require('../module');
 
@@ -26,6 +27,10 @@ pivotTableDirective.init(ngModule);
 factsDirective.init(ngModule);
 sankeyDirective.init(ngModule);
 radarDirective.init(ngModule);
+
+babbageApiExporter.setExportFunc(function(key, value) {
+  window[key] = value;
+});
 
 // Application directives
 require('./autoselect');

--- a/app/front/scripts/directives/visualizations/barchart/index.js
+++ b/app/front/scripts/directives/visualizations/barchart/index.js
@@ -34,6 +34,10 @@ ngModule.directive('barChartVisualization', [
             });
           }
         }, true);
+
+        $scope.$on('babbage-ui.ready', function() {
+          Configuration.sealerHook(200); // Wait for rendering
+        });
       }
     };
   }

--- a/app/front/scripts/directives/visualizations/bubbletree/index.js
+++ b/app/front/scripts/directives/visualizations/bubbletree/index.js
@@ -41,6 +41,10 @@ ngModule.directive('bubbleTreeVisualization', [
             $scope.$emit(Configuration.events.visualizations.drillDown,
               item.key);
           });
+
+        $scope.$on('babbage-ui.ready', function() {
+          Configuration.sealerHook(500); // Wait for animation
+        });
       }
     };
   }

--- a/app/front/scripts/directives/visualizations/facts/index.js
+++ b/app/front/scripts/directives/visualizations/facts/index.js
@@ -32,6 +32,10 @@ ngModule.directive('factsVisualization', [
             });
           }
         }, true);
+
+        $scope.$on('babbage-ui.ready', function() {
+          Configuration.sealerHook(200); // Allow angular to build table
+        });
       }
     };
   }

--- a/app/front/scripts/directives/visualizations/linechart/index.js
+++ b/app/front/scripts/directives/visualizations/linechart/index.js
@@ -32,6 +32,10 @@ ngModule.directive('lineChartVisualization', [
             });
           }
         }, true);
+
+        $scope.$on('babbage-ui.ready', function() {
+          Configuration.sealerHook(200); // Wait for rendering
+        });
       }
     };
   }

--- a/app/front/scripts/directives/visualizations/map/index.js
+++ b/app/front/scripts/directives/visualizations/map/index.js
@@ -32,6 +32,10 @@ ngModule.directive('mapVisualization', [
             });
           }
         }, true);
+
+        $scope.$on('babbage-ui.ready', function() {
+          Configuration.sealerHook(500); // Wait for animation
+        });
       }
     };
   }

--- a/app/front/scripts/directives/visualizations/piechart/index.js
+++ b/app/front/scripts/directives/visualizations/piechart/index.js
@@ -41,6 +41,10 @@ ngModule.directive('pieChartVisualization', [
             $scope.$emit(Configuration.events.visualizations.drillDown,
               item.id);
           });
+
+        $scope.$on('babbage-ui.ready', function() {
+          Configuration.sealerHook(200); // Wait for rendering
+        });
       }
     };
   }

--- a/app/front/scripts/directives/visualizations/pivottable/index.js
+++ b/app/front/scripts/directives/visualizations/pivottable/index.js
@@ -32,6 +32,7 @@ ngModule.directive('pivotTableVisualization', [
           $timeout(function() {
             if (table) {
               table.update();
+              Configuration.sealerHook(100);
             }
           }, 50);
         });

--- a/app/front/scripts/directives/visualizations/radar/index.js
+++ b/app/front/scripts/directives/visualizations/radar/index.js
@@ -32,6 +32,10 @@ ngModule.directive('radarChartVisualization', [
             });
           }
         }, true);
+
+        $scope.$on('babbage-ui.ready', function() {
+          Configuration.sealerHook(200); // Wait for rendering
+        });
       }
     };
   }

--- a/app/front/scripts/directives/visualizations/sankey/index.js
+++ b/app/front/scripts/directives/visualizations/sankey/index.js
@@ -43,6 +43,10 @@ ngModule.directive('sankeyVisualization', [
                 item.source.key);
             }
           });
+
+        $scope.$on('babbage-ui.ready', function() {
+          Configuration.sealerHook(200); // Wait for rendering
+        });
       }
     };
   }

--- a/app/front/scripts/directives/visualizations/table/index.js
+++ b/app/front/scripts/directives/visualizations/table/index.js
@@ -34,6 +34,10 @@ ngModule.directive('tableVisualization', [
             });
           }
         }, true);
+
+        $scope.$on('babbage-ui.ready', function() {
+          Configuration.sealerHook(200); // Allow angular to build table
+        });
       }
     };
   }

--- a/app/front/scripts/directives/visualizations/treemap/index.js
+++ b/app/front/scripts/directives/visualizations/treemap/index.js
@@ -41,6 +41,10 @@ ngModule.directive('treemapVisualization', [
             $scope.$emit(Configuration.events.visualizations.drillDown,
               item.key);
           });
+
+        $scope.$on('babbage-ui.ready', function() {
+          Configuration.sealerHook(500); // Wait for animation
+        });
       }
     };
   }

--- a/app/front/scripts/module.js
+++ b/app/front/scripts/module.js
@@ -15,12 +15,16 @@ if (!isAuthModuleAvailable) {
   // Fake auth library
   angular.module('authClient.services', [])
     .value('authenticate', {
-      check: function() { return new Promise(function() {}); },
+      check: function() {
+        return new Promise(function() {});
+      },
       login: function() {},
       logout: function() {}
     })
     .value('authorize', {
-      check: function() { return new Promise(function() {}); }
+      check: function() {
+        return new Promise(function() {});
+      }
     });
 }
 

--- a/app/front/scripts/module.js
+++ b/app/front/scripts/module.js
@@ -1,14 +1,40 @@
 'use strict';
 
+var Promise = require('bluebird');
 var angular = require('angular');
 require('angular-marked');
 require('angular-filter');
 require('angular-animate');
 
+var isAuthModuleAvailable = false;
+try {
+  isAuthModuleAvailable = !!angular.module('authClient.services');
+} catch (e) {
+}
+if (!isAuthModuleAvailable) {
+  // Fake auth library
+  angular.module('authClient.services', [])
+    .value('authenticate', {
+      check: function() { return new Promise(function() {}); },
+      login: function() {},
+      logout: function() {}
+    })
+    .value('authorize', {
+      check: function() { return new Promise(function() {}); }
+    });
+}
 
 var visualizations = require('./services/visualizations');
 
+window['@@sealer_hook'] = false;
+
 var config = {
+  sealerHook: function(delay) {
+    delay = parseInt(delay, 10) || 0;
+    setTimeout(function() {
+      window['@@sealer_hook'] = true;
+    }, delay > 0 ? delay : 0);
+  },
   events: {
     packageSelector: {
       change: 'packageSelector.change'

--- a/app/views/layouts/base.html
+++ b/app/views/layouts/base.html
@@ -23,7 +23,7 @@
   {% include "../partials/snippets.html" %}
 </head>
 <body ng-controller="MainController"
-      ng-init='isEmbedded=false; disablePackageSelector={{ 'true' if isEmbedded else 'false' }}; theme={{ theme | stringify }}'>
+      ng-init='isEmbedded=false; isMainView=true; disablePackageSelector={{ 'true' if isEmbedded else 'false' }}; theme={{ theme | stringify }}'>
 <div id="root"></div>
 
 {% if not isEmbedded %}

--- a/app/views/layouts/embedded.html
+++ b/app/views/layouts/embedded.html
@@ -14,10 +14,9 @@
   {% include "partials/share.html" %}
   {% include "../partials/snippets.html" %}
 </head>
-<body ng-controller="MainController" ng-init="isEmbedded=true; disablePackageSelector=true">
+<body ng-controller="MainController" ng-init="isEmbedded=true; isMainView=false; disablePackageSelector=true">
   {% block content %}{% endblock %}
 
-  <script src="scripts/app.js?{{ sessionSalt }}"></script>
-  <script src="{{ authLibraryUrl }}"></script>
+  <script src="scripts/app.js?{{ sessionSalt }}" async></script>
 </body>
 </html>


### PR DESCRIPTION
Set of improvements that allows to create screenshots faster:

- Better implementation of hooks for sealer (no need to wait 5 seconds - notify sealer as soon as visualizations are ready).
- Removed some unnecessary API calls on each visualization embedding page.
- Do not use auth lib on visualizations embedding page (as, anyway, it's not actually used) - save one network request.