### PR TITLE
[#1197] limit piechart categories

### DIFF
--- a/app/config/index.js
+++ b/app/config/index.js
@@ -3,7 +3,7 @@
 var path = require('path');
 var nconf = require('nconf');
 
-var DEFAULT_HOST = '//next.openspending.org';
+var DEFAULT_HOST = 'https://next.openspending.org';
 var DEFAULT_BASE_PATH = '';
 
 nconf.file({

--- a/app/front/scripts/directives/visualizations/piechart/index.js
+++ b/app/front/scripts/directives/visualizations/piechart/index.js
@@ -39,8 +39,13 @@ ngModule.directive('pieChartVisualization', [
         $scope.$on('babbage-ui.click',
           function($event, component, item) {
             $event.stopPropagation();
-            $scope.$emit(Configuration.events.visualizations.drillDown,
-              item.id);
+
+            if (item.id !== 'others') {
+              $scope.$emit(
+                Configuration.events.visualizations.drillDown,
+                item.id
+              );
+            }
           });
 
         $scope.$on('babbage-ui.ready', function() {

--- a/app/front/scripts/directives/visualizations/piechart/template.html
+++ b/app/front/scripts/directives/visualizations/piechart/template.html
@@ -8,6 +8,7 @@
     state="state"
     format-value="formatValue"
     messages="messages"
-    endpoint="{{ params.babbageApiUrl }}">
+    endpoint="{{ params.babbageApiUrl }}"
+    max-slices="5">
   </pie-chart>
 </div>

--- a/app/front/scripts/services/visualizations/index.js
+++ b/app/front/scripts/services/visualizations/index.js
@@ -278,24 +278,25 @@ function formatValue(scale) {
 }
 
 function getBabbageUIMessages(i18n) {
- return _.chain([
-   'loadingData',
-   'noDataAvailable',
-   'tooManyCategories',
-   'chooseRowsAndColumns',
-   'tooMuchData',
-   'showList',
-   'hideList',
-   'title',
-   'amount',
-   'percentage',
-   'total'
- ])
-   .map(function(value) {
-     return [value, i18n('BabbageUI.' + value)];
-   })
-   .fromPairs()
-   .value();
+  return _.chain([
+    'loadingData',
+    'noDataAvailable',
+    'tooManyCategories',
+    'chooseRowsAndColumns',
+    'tooMuchData',
+    'showList',
+    'hideList',
+    'title',
+    'amount',
+    'percentage',
+    'total',
+    'others',
+  ])
+    .map(function(value) {
+      return [value, i18n('BabbageUI.' + value)];
+    })
+    .fromPairs()
+    .value();
 }
 
 module.exports.formatValue = formatValue;

--- a/app/front/styles/_pie.less
+++ b/app/front/styles/_pie.less
@@ -1,0 +1,7 @@
+.pie-chart {
+  .c3-target-others path {
+    // Target the "Others" slice in a pie chart
+    // This !important is needed to overwrite c3js's inline styles
+    cursor: default !important;
+  }
+}

--- a/app/front/styles/_visualizations.less
+++ b/app/front/styles/_visualizations.less
@@ -1,0 +1,2 @@
+@import "./_pivot.less";
+@import "./_pie.less";

--- a/app/front/styles/embedded.less
+++ b/app/front/styles/embedded.less
@@ -62,4 +62,4 @@ a {
   margin: 0 !important;
 }
 
-@import "./_pivot.less";
+@import "./_visualizations.less";

--- a/app/front/styles/styles.less
+++ b/app/front/styles/styles.less
@@ -498,4 +498,4 @@ textarea {
   max-height: 700px;
 }
 
-@import "./_pivot.less";
+@import "./_visualizations.less";

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "angular-animate": "^1.5.8",
     "angular-filter": "^0.5.9",
     "angular-marked": "^1.2.2",
-    "babbage.ui": "^1.3.0",
+    "babbage.ui": "^1.4.0",
     "bluebird": "^3.0.5",
     "body-parser": "^1.14.1",
     "bubbletree": "git+https://github.com/okfn/bubbletree.git",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "start": "node index.js",
     "test": "mocha tests/*.js",
     "review": "eslint app tests index.js gulpfile.js webpack.config.js --ignore-pattern 'app/views/snippets/*'",
-    "develop": "gulp && npm start",
+    "develop": "npm run build && npm start",
     "build:assets": "gulp",
     "build:app": "webpack --hide-modules --config webpack.config.js",
     "build": "npm run build:assets && npm run build:app"

--- a/translations/en.json
+++ b/translations/en.json
@@ -17,6 +17,7 @@
   "BabbageUI.tooManyCategories": "<strong>Too many categories.</strong> The breakdown you have selected contains many different categories, only the {count} biggest are shown.",
   "BabbageUI.tooMuchData": "<strong>Oh snap!</strong> The query returns too much data and can't be displayed in the table. Try the DataMine instead or another query.",
   "BabbageUI.total": "Total",
+  "BabbageUI.others": "Others",
   "Bar Chart": "Bar Chart",
   "Bubble Tree": "Bubble Tree",
   "Budget Line Id": "Budget Line Id",

--- a/translations/es.json
+++ b/translations/es.json
@@ -17,6 +17,7 @@
   "BabbageUI.tooManyCategories": "<strong>Demasiadas categor\u00edas.</strong> El desglose elegido contiene demasiadas categorias, \u00fanicamente se muestran las {count} m\u00e1s grandes. ",
   "BabbageUI.tooMuchData": "<strong>Oh cielos!</strong> La consulta devuelve demasiados datos y no pueden mostrarse en una tabla. Prueba el DataMine u otra consulta.",
   "BabbageUI.total": "Total",
+  "BabbageUI.others": "Otros",
   "Bar Chart": "Gr\u00e1fica de Barras",
   "Bubble Tree": "Gr\u00e1fica de Burbujas",
   "Budget Line Id": "Clave de Cartera",


### PR DESCRIPTION
The slice that groups the smaller values can't be clicked on, as it makes no
sense to drill down in multiple categories. Unfortunately, the way we detect if
the slice is the "Others" slice is by checking its name. Ideally, we would have
a flag in the "Others" slice, but that wasn't possible.

I also was unable to remove the pointer cursor on the "Others" slice, which is
confusing for the user. To do that, we need a stable class name, but the class
is based on the slice's label, which can change depending on the site language.
I'll open an issue for this.

Fixes openspending/openspending#1197