### PR TITLE
Alter color scales for Bar, Line, Pie, Radar, Sankey and Treemap

### DIFF
--- a/app/front/scripts/directives/visualizations/barchart/index.js
+++ b/app/front/scripts/directives/visualizations/barchart/index.js
@@ -23,6 +23,7 @@ ngModule.directive('barChartVisualization', [
           .paramsToBabbageState($scope.params);
 
         $scope.formatValue = Configuration.formatValue;
+        $scope.colorScale = Configuration.colorScales.constant();
         $scope.messages = visualizationsService.getBabbageUIMessages(i18n);
 
         $scope.$watch('params', function(newValue, oldValue) {

--- a/app/front/scripts/directives/visualizations/barchart/template.html
+++ b/app/front/scripts/directives/visualizations/barchart/template.html
@@ -12,6 +12,7 @@
     state="state"
     format-value="formatValue"
     messages="messages"
-    endpoint="{{ params.babbageApiUrl }}">
+    endpoint="{{ params.babbageApiUrl }}"
+    color-scale="colorScale">
   </chart>
 </div>

--- a/app/front/scripts/directives/visualizations/linechart/index.js
+++ b/app/front/scripts/directives/visualizations/linechart/index.js
@@ -21,6 +21,7 @@ ngModule.directive('lineChartVisualization', [
           .paramsToBabbageStateTimeSeries($scope.params);
 
         $scope.formatValue = Configuration.formatValue;
+        $scope.colorScale = Configuration.colorScales.categorical();
         $scope.messages = visualizationsService.getBabbageUIMessages(i18n);
 
         $scope.$watch('params', function(newValue, oldValue) {

--- a/app/front/scripts/directives/visualizations/linechart/template.html
+++ b/app/front/scripts/directives/visualizations/linechart/template.html
@@ -6,6 +6,7 @@
     state="state"
     format-value="formatValue"
     messages="messages"
-    endpoint="{{ params.babbageApiUrl }}">
+    endpoint="{{ params.babbageApiUrl }}"
+    color-scale="colorScale">
   </chart>
 </div>

--- a/app/front/scripts/directives/visualizations/piechart/index.js
+++ b/app/front/scripts/directives/visualizations/piechart/index.js
@@ -23,6 +23,7 @@ ngModule.directive('pieChartVisualization', [
           .paramsToBabbageState($scope.params);
 
         $scope.formatValue = Configuration.formatValue;
+        $scope.colorScale = Configuration.colorScales.categorical();
         $scope.messages = visualizationsService.getBabbageUIMessages(i18n);
 
         $scope.$watch('params', function(newValue, oldValue) {

--- a/app/front/scripts/directives/visualizations/piechart/template.html
+++ b/app/front/scripts/directives/visualizations/piechart/template.html
@@ -9,6 +9,7 @@
     format-value="formatValue"
     messages="messages"
     endpoint="{{ params.babbageApiUrl }}"
-    max-slices="5">
+    max-slices="5"
+    color-scale="colorScale">
   </pie-chart>
 </div>

--- a/app/front/scripts/directives/visualizations/radar/index.js
+++ b/app/front/scripts/directives/visualizations/radar/index.js
@@ -21,6 +21,7 @@ ngModule.directive('radarChartVisualization', [
           .paramsToBabbageStateRadar($scope.params);
 
         $scope.formatValue = Configuration.formatValue;
+        $scope.colorScale = Configuration.colorScales.categorical();
         $scope.messages = visualizationsService.getBabbageUIMessages(i18n);
 
         $scope.$watch('params', function(newValue, oldValue) {

--- a/app/front/scripts/directives/visualizations/radar/template.html
+++ b/app/front/scripts/directives/visualizations/radar/template.html
@@ -12,7 +12,9 @@
       state="state"
       format-value="formatValue"
       messages="messages"
-      endpoint="{{ params.babbageApiUrl }}">
+      endpoint="{{ params.babbageApiUrl }}"
+      color-scale="colorScale"
+    >
     </radar-chart>
   </div>
 </div>

--- a/app/front/scripts/directives/visualizations/sankey/index.js
+++ b/app/front/scripts/directives/visualizations/sankey/index.js
@@ -23,6 +23,7 @@ ngModule.directive('sankeyVisualization', [
           .paramsToBabbageStateSankey($scope.params);
 
         $scope.formatValue = Configuration.formatValue;
+        $scope.colorScale = Configuration.colorScales.categorical();
         $scope.messages = visualizationsService.getBabbageUIMessages(i18n);
 
         $scope.$watch('params', function(newValue, oldValue) {

--- a/app/front/scripts/directives/visualizations/sankey/template.html
+++ b/app/front/scripts/directives/visualizations/sankey/template.html
@@ -8,6 +8,8 @@
     state="state"
     format-value="formatValue"
     messages="messages"
-    endpoint="{{ params.babbageApiUrl }}">
+    endpoint="{{ params.babbageApiUrl }}"
+    color-scale="colorScale"
+  >
   </san-key-chart>
 </div>

--- a/app/front/scripts/directives/visualizations/treemap/index.js
+++ b/app/front/scripts/directives/visualizations/treemap/index.js
@@ -23,6 +23,7 @@ ngModule.directive('treemapVisualization', [
           .paramsToBabbageState($scope.params);
 
         $scope.formatValue = Configuration.formatValue;
+        $scope.colorScale = Configuration.colorScales.constant();
         $scope.messages = visualizationsService.getBabbageUIMessages(i18n);
 
         $scope.$watch('params', function(newValue, oldValue) {

--- a/app/front/scripts/directives/visualizations/treemap/template.html
+++ b/app/front/scripts/directives/visualizations/treemap/template.html
@@ -8,6 +8,7 @@
     state="state"
     format-value="formatValue"
     messages="messages"
-    endpoint="{{ params.babbageApiUrl }}">
+    endpoint="{{ params.babbageApiUrl }}"
+    color-scale="colorScale">
   </tree-map>
 </div>

--- a/app/front/scripts/module.js
+++ b/app/front/scripts/module.js
@@ -65,7 +65,11 @@ var config = {
       setFilter: 'sidebar.setFilter',
       clearFilter: 'sidebar.clearFilter'
     }
-  }
+  },
+  colorScales: {
+    categorical: d3.scale.category10,
+    constant: () => (() => '#1f78b4'),
+  },
 };
 
 var ngModule = angular.module('Application', [


### PR DESCRIPTION
Most of them are now using `d3.scale.category10()`, while the Bar Chart and
Treeemap use a constant color (blueish, the first color of the category scale).
The remaining charts are the Map and Bubble Tree. Both weren't modified now
because they require a different treatment, as the Map doesn't use a categorical
scale, and the Bubble Tree doesn't use D3.

Fixes openspending/openspending#1203
Fixes openspending/openspending#1200

Note that the following before/after changes also contain modifications already merged (e.g. font sizes). The change in this PR is exclusive to colours.

# Before
![Before - Treemap, Pie chart and Sankey](https://cloud.githubusercontent.com/assets/76945/26316586/a3928524-3f0c-11e7-8de8-f7aa87234a7d.png)
![Before - Bar chart](https://cloud.githubusercontent.com/assets/76945/26316594/aaf892a4-3f0c-11e7-83d8-4683ee2ebc49.png)
![Before - Line chart](https://cloud.githubusercontent.com/assets/76945/26316702/0d769f16-3f0d-11e7-9288-91dbdef5d9d0.png)

# After
![After - Treemap, Pie chart and Sankey](https://cloud.githubusercontent.com/assets/76945/26316580/9f727d96-3f0c-11e7-96d2-1d887f4b387d.png)
![After - Bar chart](https://cloud.githubusercontent.com/assets/76945/26316592/a98db764-3f0c-11e7-92a0-eaf7c14b42cf.png)
![After - Line chart](https://cloud.githubusercontent.com/assets/76945/26316716/18447b66-3f0d-11e7-8e8e-d2fc687f4762.png)