### PR TITLE
[#1234] Fix bug with initial sankey data state and some other improvements

### DIFF
--- a/app/front/scripts/services/os-viewer/params.js
+++ b/app/front/scripts/services/os-viewer/params.js
@@ -14,6 +14,8 @@ function getDefaultState(variablePart) {
     measures: [],
     groups: [],
     series: [],
+    source: undefined,
+    target: undefined,
     rows: [],
     columns: [],
     filters: {},
@@ -642,7 +644,7 @@ function removeAllVisualizations(state, packageModel) {
 function updateFromParams(state, urlParams, packageModel) {
   urlParams = normalizeUrlParams(urlParams || {}, packageModel);
   urlParams = validateUrlParams(urlParams, packageModel);
-  var result = _.extend(cloneState(state), getDefaultState(), urlParams);
+  var result = _.extend(getDefaultState(), cloneState(state), urlParams);
   updateSourceTarget(result, packageModel);
   return result;
 }
@@ -662,3 +664,4 @@ module.exports.removeVisualization = removeVisualization;
 module.exports.removeAllVisualizations = removeAllVisualizations;
 module.exports.changeOrderBy = changeOrderBy;
 module.exports.updateFromParams = updateFromParams;
+module.exports._getDefaultState = getDefaultState;

--- a/app/front/scripts/services/os-viewer/params.js
+++ b/app/front/scripts/services/os-viewer/params.js
@@ -190,18 +190,17 @@ function validateUrlParams(params, packageModel) {
 }
 
 function init(packageModel, initialParams) {
-  var anyDateTimeHierarchy = _.first(packageModel.dateTimeHierarchies);
-  initialParams = normalizeUrlParams(initialParams || {}, packageModel);
-  initialParams = validateUrlParams(initialParams, packageModel);
-
-  var defaults = getDefaultState({
+  const anyDateTimeHierarchy = _.first(packageModel.dateTimeHierarchies);
+  const defaults = getDefaultState({
     packageId: packageModel.id,
     countryCode: packageModel.meta.countryCode,
     dateTimeDimension: anyDateTimeHierarchy ?
       _.first(anyDateTimeHierarchy.dimensions).key : null
   });
 
-  return _.extend(defaults, initialParams);
+  return updateFromParams(
+    defaults, initialParams || {}, packageModel
+  );
 }
 
 function changeMeasure(state, measure) {

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "gulp-rename": "^1.2.2",
     "gulp-sourcemaps": "^1.6.0",
     "json-loader": "^0.5.4",
-    "mocha": "^2.3.3",
+    "mocha": "^3.4.2",
     "nock": "^7.2.2",
     "null-loader": "^0.1.1",
     "raphael": "^2.1.4",

--- a/tests/data/package1-initial-state.js
+++ b/tests/data/package1-initial-state.js
@@ -20,7 +20,9 @@ module.exports = {
     countryCode: 'CM',
     dateTimeDimension: 'date_2.Annee',
     babbageApiUrl: 'http://api.example.com',
-    cosmopolitanApiUrl: 'http://cosmopolitan.example.com'
+    cosmopolitanApiUrl: 'http://cosmopolitan.example.com',
+    source: undefined,
+    target: undefined
   },
   history: {
     items: [],

--- a/tests/os-viewer.js
+++ b/tests/os-viewer.js
@@ -287,4 +287,43 @@ describe('OS Viewer core service', function() {
         .catch(done);
     });
   });
+
+  describe('updateFromParams', () => {
+    it('returns default state if received empty state and URL params', () => {
+      const packageModel = data.package1PackageModel;
+      const stateParams = {};
+      const urlParams = {};
+
+      const params = paramsService.updateFromParams(stateParams, urlParams, packageModel);
+
+      assert.deepEqual(params, paramsService._getDefaultState());
+    });
+
+    it('it does not overwrite the state params if there is no new value in the URL params', () => {
+      const packageModel = data.package1PackageModel;
+      const stateParams = {
+        visualizations: ['Treemap'],
+      };
+      const urlParams = {};
+
+      const params = paramsService.updateFromParams(stateParams, urlParams, packageModel);
+
+      assert.deepEqual(params.visualizations, stateParams.visualizations);
+    });
+
+    it('it overwrites the state params if there is another value in the URL params', () => {
+      // I'm using "visualizations" here, but this should apply to any value in stateParams
+      const packageModel = data.package1PackageModel;
+      const stateParams = {
+        visualizations: ['Treemap'],
+      };
+      const urlParams = {
+        visualizations: ['PieChart'],
+      };
+
+      const params = paramsService.updateFromParams(stateParams, urlParams, packageModel);
+
+      assert.deepEqual(params.visualizations, urlParams.visualizations);
+    });
+  });
 });

--- a/tests/os-viewer.js
+++ b/tests/os-viewer.js
@@ -170,6 +170,28 @@ describe('OS Viewer core service', function() {
       });
       done();
     });
+
+    it('Should set the params groups, source and target correctly', function() {
+      // See bug https://github.com/openspending/openspending/issues/1234
+      const packageModel = data.package1PackageModel;
+      const hierarchy = _.find(packageModel.hierarchies, (hierarchy) => hierarchy.dimensions.length > 1);
+
+      assert.isDefined(
+        hierarchy,
+        'We need a hierarchy with more than 1 dimension to test this behaviour'
+      );
+
+      const initialParams = {
+        groups: [hierarchy.dimensions[0].key],
+        visualizations: ['Treemap'],
+      };
+
+      const params = paramsService.init(packageModel, initialParams);
+
+      assert.deepEqual(params.groups, initialParams.groups);
+      assert.equal(params.source, hierarchy.dimensions[0].key);
+      assert.equal(params.target, hierarchy.dimensions[1].key);
+    });
   });
 
   describe('Core', function() {


### PR DESCRIPTION
The main issue with this PR fixes openspending/openspending#1234 (commit https://github.com/openspending/os-viewer/commit/b203cf9741d9ffc2c4864403c61ffbc0a09dc6aa).

We also upgrade Mocha, so we can use its new Chrome Debugging features, and add tests and fix a bug with `paramsService.updateFromParams()`.

Please, check the commit messages to understand better what this PR fixes.

When merging, don't squash the commits, as even though they're in the same PR, they are independent.