### PR TITLE
[#1280] Remove "Raphael" dependency

### DIFF
--- a/app/front/scripts/index.js
+++ b/app/front/scripts/index.js
@@ -14,7 +14,6 @@ var _ = require('lodash');
   globals.jQuery = globals.$ = jquery;
   globals.d3 = require('d3');
   globals.c3 = require('c3');
-  globals.Raphael = require('raphael');
 
   // fetch() polyfill
   require('isomorphic-fetch/fetch-npm-browserify');

--- a/package.json
+++ b/package.json
@@ -82,7 +82,6 @@
     "mocha": "^3.4.2",
     "nock": "^7.2.2",
     "null-loader": "^0.1.1",
-    "raphael": "^2.1.4",
     "raw-loader": "^0.5.1",
     "supertest": "^1.2.0",
     "val-loader": "^0.5.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -29,13 +29,6 @@ module.exports = {
     filename: '[name].js',
     path: './public/scripts'
   },
-  resolve: {
-    alias: {
-      // Use `webpack-raphael` instead of `raphael` which is somehow
-      // incompatible with webpack
-      raphael$: 'webpack-raphael'
-    }
-  },
   module: {
     loaders: [
       {test: /\.html$/, loader: 'raw'},


### PR DESCRIPTION
Raphael is only used by "bubbletree", and it loads this dependency itself, so
there's no need for us to load it here.

Fixes openspending/openspending#1280