### PR TITLE
[#1274] Fix bug where we called encodeURIComponent() twice

### DIFF
--- a/app/front/scripts/services/data-package-api/index.js
+++ b/app/front/scripts/services/data-package-api/index.js
@@ -193,7 +193,7 @@ function loadDimensionValues(packageId, dimension, filters) {
 
     var cut = _.extend({}, filters);
     delete cut[dimension.key];
-    cut = serializeCut(cut);
+    cut = serializeCut(cut).join('|');
     if (cut != '') {
       cut = '?cut=' + encodeURIComponent(cut);
     }
@@ -421,7 +421,6 @@ function serializeCut(filters, drilldown) {
         .join(';')
         .value();
     })
-    .map(encodeURIComponent)
     .value();
 }
 

--- a/tests/visualizations.js
+++ b/tests/visualizations.js
@@ -94,7 +94,7 @@ describe('Visualizations', function() {
         aggregates: 'Depenses_realisees.sum',
         group: ['date_2.Annee'],
         filter: [
-          encodeURIComponent('economic_classification_Compte.Compte:"610100"')
+          'economic_classification_Compte.Compte:"610100"'
         ],
         order: [{
           key: 'Depenses_realisees.sum',
@@ -111,7 +111,7 @@ describe('Visualizations', function() {
         aggregates: 'Depenses_realisees.sum',
         group: ['date_2.Annee'],
         filter: [
-          encodeURIComponent('economic_classification_Compte.Compte:"610100"')
+          'economic_classification_Compte.Compte:"610100"'
         ]
       });
       done();
@@ -124,7 +124,7 @@ describe('Visualizations', function() {
         rows: ['date_2.Annee'],
         cols: ['economic_classification_3.Article'],
         filter: [
-          encodeURIComponent('economic_classification_Compte.Compte:"610100"')
+          'economic_classification_Compte.Compte:"610100"'
         ],
         order: [{
           key: 'Depenses_realisees.sum',
@@ -140,7 +140,7 @@ describe('Visualizations', function() {
         aggregates: 'Depenses_realisees.sum',
         group: ['date_2.Annee'],
         filter: [
-          encodeURIComponent('economic_classification_Compte.Compte:"610100"')
+          'economic_classification_Compte.Compte:"610100"'
         ],
         order: [{
           key: 'date_2.Annee',


### PR DESCRIPTION
We should only call it once, otherwise a string like `date:2017` becomes
`date%3A2017` in the first call, and `date%253A2017` in the second call. In
other words, `encodeURIComponent()` encodes the `%` in `date%3A2017`.

Fixes openspending/openspending#1274