### PR TITLE
[#1292] Fix English plural of numbers

### DIFF
--- a/app/front/scripts/services/visualizations/index.js
+++ b/app/front/scripts/services/visualizations/index.js
@@ -234,9 +234,9 @@ function formatValue(scale) {
   }
   if (!_.isObject(scale)) {
     scale = {
-      Billions: 1000000000,
-      Millions: 1000000,
-      Thousands: 1000
+      Billion: 1000000000,
+      Million: 1000000,
+      Thousand: 1000
     };
   }
 

--- a/translations/en.json
+++ b/translations/en.json
@@ -71,7 +71,7 @@
   "Table": "Table",
   "Tree Map": "Tree Map",
   "Unknown": "Unknown",
-  "Value Formatting Scale": "\"Billions\": 1000000000, \"Millions\": 1000000, \"Thousands\": 1000",
+  "Value Formatting Scale": "\"Billion\": 1000000000, \"Million\": 1000000, \"Thousand\": 1000",
   "View Raw Source Data": "View Raw Source Data",
   "X-Axis": "X-Axis",
   "existing visualizations to enable full range of visualization types.": "existing visualizations to enable full range of visualization types."


### PR DESCRIPTION
It should be 3.2 Billion, not Billions (note the singular/plural).

Fixes openspending/openspending#1292