### PR TITLE
Increase contrast of DataPackage descriptions

### DIFF
--- a/app/front/styles/styles.less
+++ b/app/front/styles/styles.less
@@ -238,7 +238,6 @@ textarea {
 
   [marked] {
     margin: 0.5em 0;
-    color: silver;
   }
 }
 


### PR DESCRIPTION
The current colour is barely readable, see the text below the "BOOST Moldova
2005-2014" header on
https://staging.openspending.org/viewer/boost:boost-moldova-2005-2014.