### PR TITLE
Allow drilldown for bar charts.

### DIFF
--- a/app/front/scripts/directives/visualizations/barchart/index.js
+++ b/app/front/scripts/directives/visualizations/barchart/index.js
@@ -37,6 +37,19 @@ ngModule.directive('barChartVisualization', [
           }
         }, true);
 
+        $scope.$on('babbage-ui.click',
+          function($event, component, item) {
+            var categoryName = component.chart.category(item['index']);
+            $event.stopPropagation();
+
+            if (categoryName.toLowerCase() !== 'others') {
+              $scope.$emit(
+                Configuration.events.visualizations.drillDown,
+                categoryName
+              );
+            }
+          });
+
         $scope.$on('babbage-ui.ready', function() {
           Configuration.sealerHook(200); // Wait for rendering
         });

--- a/app/front/scripts/directives/visualizations/barchart/index.js
+++ b/app/front/scripts/directives/visualizations/barchart/index.js
@@ -5,6 +5,7 @@ var downloader = require('../../../services/downloader');
 var visualizationsService = require('../../../services/visualizations');
 
 require('../controls/sorting');
+require('../controls/breadcrumbs');
 
 ngModule.directive('barChartVisualization', [
   '$timeout', 'i18n', 'Configuration',

--- a/app/front/scripts/directives/visualizations/barchart/template.html
+++ b/app/front/scripts/directives/visualizations/barchart/template.html
@@ -1,3 +1,6 @@
+<div class="clearfix">
+  <breadcrumbs breadcrumbs="params.breadcrumbs"></breadcrumbs>
+</div>
 <div ng-if="!params.isEmbedded" class="clearfix">
   <sorting-control
     selected="params.orderBy"

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "posttest": "npm run review",
     "review": "eslint app tests index.js gulpfile.js webpack.config.js --ignore-pattern 'app/views/snippets/*'",
     "develop": "npm run build && npm start",
+    "debug": "npm run build && node --inspect index.js",
     "build:assets": "gulp",
     "build:app": "webpack --hide-modules --config webpack.config.js",
     "build": "npm run build:assets && npm run build:app"

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "angular-animate": "^1.5.8",
     "angular-filter": "^0.5.9",
     "angular-marked": "^1.2.2",
-    "babbage.ui": "^1.6.0",
+    "babbage.ui": "^1.6.1",
     "bluebird": "^3.0.5",
     "body-parser": "^1.14.1",
     "bubbletree": "^2.1.0",


### PR DESCRIPTION
This PR allows drilldown into bar charts. `click` events are added to the chart component in openspending/babbage.ui#72 (reviewer: please also review this PR), and the category name is passed the drilldown event.

Fixes openspending/openspending#1282.