### PR TITLE
Add donut visualisation

### DIFF
--- a/app/front/scripts/directives/visualizations/donutchart/index.js
+++ b/app/front/scripts/directives/visualizations/donutchart/index.js
@@ -1,0 +1,58 @@
+'use strict';
+
+var ngModule = require('../../../module');
+var downloader = require('../../../services/downloader');
+var visualizationsService = require('../../../services/visualizations');
+
+require('../controls/breadcrumbs');
+
+ngModule.directive('donutChartVisualization', [
+  '$timeout', 'i18n', 'Configuration',
+  function($timeout, i18n, Configuration) {
+    return {
+      template: require('./template.html'),
+      replace: false,
+      restrict: 'E',
+      scope: {
+        params: '='
+      },
+      link: function($scope) {
+        $scope.downloader = downloader;
+        $scope.isVisible = true;
+        $scope.state = visualizationsService
+          .paramsToBabbageState($scope.params);
+
+        $scope.formatValue = Configuration.formatValue;
+        $scope.colorScale = Configuration.colorScales.categorical();
+        $scope.messages = visualizationsService.getBabbageUIMessages(i18n);
+
+        $scope.$watch('params', function(newValue, oldValue) {
+          if (newValue !== oldValue) {
+            $scope.state = visualizationsService
+              .paramsToBabbageState($scope.params);
+            $scope.isVisible = false;
+            $timeout(function() {
+              $scope.isVisible = true;
+            });
+          }
+        }, true);
+
+        $scope.$on('babbage-ui.click',
+          function($event, component, item) {
+            $event.stopPropagation();
+
+            if (item.id !== 'others') {
+              $scope.$emit(
+                Configuration.events.visualizations.drillDown,
+                item.id
+              );
+            }
+          });
+
+        $scope.$on('babbage-ui.ready', function() {
+          Configuration.sealerHook(200); // Wait for rendering
+        });
+      }
+    };
+  }
+]);

--- a/app/front/scripts/directives/visualizations/donutchart/template.html
+++ b/app/front/scripts/directives/visualizations/donutchart/template.html
@@ -1,0 +1,16 @@
+<div class="clearfix">
+  <breadcrumbs breadcrumbs="params.breadcrumbs"></breadcrumbs>
+</div>
+<div class="x-visualization-chart clearfix">
+  <pie-chart ng-if="isVisible"
+    downloader="downloader"
+    cube="{{ params.packageId }}"
+    type="donut"
+    state="state"
+    format-value="formatValue"
+    messages="messages"
+    endpoint="{{ params.babbageApiUrl }}"
+    max-slices="5"
+    color-scale="colorScale">
+  </pie-chart>
+</div>

--- a/app/front/scripts/directives/visualizations/index.js
+++ b/app/front/scripts/directives/visualizations/index.js
@@ -11,6 +11,7 @@ require('./facts');
 require('./linechart');
 require('./map');
 require('./piechart');
+require('./donutchart');
 require('./pivottable');
 require('./radar');
 require('./sankey');

--- a/app/front/scripts/directives/visualizations/visualization-container/template.html
+++ b/app/front/scripts/directives/visualizations/visualization-container/template.html
@@ -2,6 +2,7 @@
   <div ng-switch="visualization.id">
     <treemap-visualization ng-switch-when="Treemap" params="params"></treemap-visualization>
     <pie-chart-visualization ng-switch-when="PieChart" params="params"></pie-chart-visualization>
+    <donut-chart-visualization ng-switch-when="DonutChart" params="params"></donut-chart-visualization>
     <bar-chart-visualization ng-switch-when="BarChart" params="params"></bar-chart-visualization>
     <sankey-visualization ng-switch-when="Sankey" params="params"></sankey-visualization>
     <line-chart-visualization ng-switch-when="LineChart" params="params"></line-chart-visualization>

--- a/app/front/scripts/services/visualizations/index.js
+++ b/app/front/scripts/services/visualizations/index.js
@@ -19,6 +19,13 @@ var availableVisualizations = [
     icon: 'os-icon os-icon-piechart'
   },
   {
+    id: 'DonutChart',
+    name: 'Donut Chart',
+    type: 'drilldown',
+    embed: 'donutchart',
+    icon: 'os-icon os-icon-piechart'
+  },
+  {
     id: 'BubbleTree',
     name: 'Bubble Tree',
     type: 'drilldown',

--- a/app/front/scripts/services/visualizations/index.js
+++ b/app/front/scripts/services/visualizations/index.js
@@ -23,7 +23,7 @@ var availableVisualizations = [
     name: 'Donut Chart',
     type: 'drilldown',
     embed: 'donutchart',
-    icon: 'os-icon os-icon-piechart'
+    icon: 'os-icon os-icon-donutchart'
   },
   {
     id: 'BubbleTree',

--- a/app/views/pages/embedded.html
+++ b/app/views/pages/embedded.html
@@ -6,6 +6,7 @@
   <div ng-switch="state.params.visualizations[0]">
     <treemap-visualization ng-switch-when="Treemap" params="state.params"></treemap-visualization>
     <pie-chart-visualization ng-switch-when="PieChart" params="state.params"></pie-chart-visualization>
+    <donut-chart-visualization ng-switch-when="DonutChart" params="state.params"></donut-chart-visualization>
     <bar-chart-visualization ng-switch-when="BarChart" params="state.params"></bar-chart-visualization>
     <line-chart-visualization ng-switch-when="LineChart" params="state.params"></line-chart-visualization>
     <table-visualization ng-switch-when="Table" params="state.params"></table-visualization>

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "angular-animate": "^1.5.8",
     "angular-filter": "^0.5.9",
     "angular-marked": "^1.2.2",
-    "babbage.ui": "^1.6.2",
+    "babbage.ui": "^1.6.3",
     "bluebird": "^3.0.5",
     "body-parser": "^1.14.1",
     "bubbletree": "^2.1.0",

--- a/tests/visualizations.js
+++ b/tests/visualizations.js
@@ -60,7 +60,7 @@ describe('Visualizations', function() {
         data.package1PackageModel);
 
       assert.isArray(items);
-      assert.equal(items.length, 9);
+      assert.equal(items.length, 10);
       _.each(items, function(item) {
         assert.isObject(item);
       });
@@ -74,6 +74,7 @@ describe('Visualizations', function() {
       assert.deepEqual(ids, [
         'BarChart',
         'BubbleTree',
+        'DonutChart',
         'LineChart',
         'PieChart',
         'PivotTable',

--- a/translations/en.json
+++ b/translations/en.json
@@ -30,6 +30,7 @@
   "Data Resources": "Data Resources",
   "Date": "Date",
   "Direction": "Direction",
+  "Donut Chart": "Donut Chart",
   "Download Data Package": "Download Data Package",
   "Download as CSV": "Download as CSV",
   "Economic Classification": "Economic Classification",


### PR DESCRIPTION
This PR adds a pie chart with type donut to the visualisation selection.

<img width="384" alt="donut-chart" src="https://user-images.githubusercontent.com/3993/35805604-6f0944ee-0a74-11e8-827f-401ce8526887.png">

babbage.ui updated to use donut charts: https://github.com/openspending/babbage.ui/compare/v1.6.2...v1.6.3
os-bootstrap updated to add donut icon to icon font updated by in https://github.com/openspending/os-bootstrap/commit/0aed1c9253b7f33030c5d467738d0cac3e4d9ad1

Fixes openspending/openspending#1298.