### PR TITLE
Throw raw server errors when requests fail

### DIFF
--- a/app/front/scripts/services/downloader/index.js
+++ b/app/front/scripts/services/downloader/index.js
@@ -27,16 +27,17 @@ function getNormalizedUrl(originalUrl) {
 module.exports = {
   get: function(url, options, bypassCache) {
     // Make cache more efficient - use normalized url
-    // console.log(url);
     url = getNormalizedUrl(url);
-    // console.log(url);
-    // console.log('');
     if (bypassCache || !cache[url]) {
       var requestPromise = fetch(url, options).then(function(response) {
-        if (response.status != 200) {
-          throw new Error('Failed loading data from ' + response.url);
+        var responseText = response.text();
+
+        if (response.status >= 400) {
+          responseText.then(function(errorText) {
+            throw errorText;
+          });
         }
-        return response.text();
+        return responseText;
       });
 
       if (bypassCache) {


### PR DESCRIPTION
This is related (and a requirement for) openspending/babbage.ui#75.

Instead of throwing a formatted error with only the URL that failed, throw the raw error object instead, as it was returned from the API.

The new babbage-ui implementation will handle and propagate this to the components.

Should be backwards compatible with anything using the old error.